### PR TITLE
generate import blocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.20.0'
+          go-version: '~1.22.0'
       - name: download tools
         env:
           GOXZ_VERSION: 0.9.1

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ resource "aws_ssm_parameter" "parameter" {
 }
 
 import {
-  from = "production/SOME_SECRET"
-  to   = aws_ssm_parameter.parameter["SOME_SECRET"]
+  id = "production/SOME_SECRET"
+  to = aws_ssm_parameter.parameter["SOME_SECRET"]
 }
 
 import {
-  from = "production/THAT_ID"
-  to   = aws_ssm_parameter.parameter["THAT_ID"]
+  id = "production/THAT_ID"
+  to = aws_ssm_parameter.parameter["THAT_ID"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ aws-secrets-dumper --target secretsmanager -prefix production/ generate import
 ```console
 $ aws-secrets-dumper -help
 NAME:
-   aws-secrets-dumper - A new cli application
+   aws-secrets-dumper - Management migration helper for secrets on AWS SSM Parameter Store and AWS Secrets Manager with terraform
 
 USAGE:
    aws-secrets-dumper [global options] command [command options] [arguments...]

--- a/cmd/aws-secrets-dumper/main.go
+++ b/cmd/aws-secrets-dumper/main.go
@@ -59,21 +59,10 @@ func main() {
 				},
 			},
 			{
-				Name:  "generate",
-				Usage: "generate something",
-				Subcommands: []*cli.Command{
-					{
-						Name: "tf",
-						Action: func(cCtx *cli.Context) error {
-							return actionGenerateTF(cCtx)
-						},
-					},
-					{
-						Name: "imports",
-						Action: func(cCtx *cli.Context) error {
-							return actionGenerateImports(cCtx)
-						},
-					},
+				Name:  "tf",
+				Usage: "output terraform resource denifition(s) to stdout",
+				Action: func(cCtx *cli.Context) error {
+					return actionGenerateTF(cCtx)
 				},
 			},
 		},
@@ -135,23 +124,6 @@ func actionGenerateTF(cCtx *cli.Context) error {
 
 	if err := svc.GenerateTF(cCtx.Context, filter, os.Stdout); err != nil {
 		return fmt.Errorf("failed to generate terraform resource definition(s): %s", err)
-	}
-
-	return nil
-}
-
-func actionGenerateImports(cCtx *cli.Context) error {
-	svc, err := initService(cCtx.String("target"))
-	if err != nil {
-		return fmt.Errorf("failed to init service for %s", cCtx.String("target"))
-	}
-
-	filter := asd.Filter{
-		Prefix: cCtx.String("prefix"),
-	}
-
-	if err := svc.GenerateImports(cCtx.Context, filter, os.Stdout); err != nil {
-		return fmt.Errorf("failed to generate terraform import command(s): %s", err)
 	}
 
 	return nil

--- a/cmd/aws-secrets-dumper/main.go
+++ b/cmd/aws-secrets-dumper/main.go
@@ -28,6 +28,7 @@ func init() {
 
 func main() {
 	app := &cli.App{
+		Usage: "Management migration helper for secrets on AWS SSM Parameter Store and AWS Secrets Manager with terraform",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "target",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/handlename/aws-secrets-dumper
 
-go 1.20
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.17.3

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.16.8
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.3
 	github.com/hashicorp/logutils v1.0.0
+	github.com/samber/lo v1.39.0
 	github.com/urfave/cli/v2 v2.23.7
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -27,4 +28,5 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -46,11 +46,15 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
+github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/urfave/cli/v2 v2.23.7 h1:YHDQ46s3VghFHFf1DdF+Sh7H4RqhcM+t0TmZRJx4oJY=
 github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
+golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/secretsmanager.go
+++ b/secretsmanager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/samber/lo"
 )
 
 type SecretsManagerService struct {
@@ -103,6 +104,11 @@ func (s SecretsManagerService) retrieveSecrets(ctx context.Context, client *secr
 }
 
 func (s SecretsManagerService) GenerateTF(ctx context.Context, filter Filter, out io.Writer) error {
+	secrets, err := s.RetrieveSecrets(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve secrets: %s", err)
+	}
+
 	tmpl, err := template.New("tf").Parse(`
 data "sops_file" "secretsmanager_secrets" {
   source_file = "{{ .EncryptedSecretFileName }}"
@@ -127,14 +133,40 @@ resource "aws_secretsmanager_secret_version" "secret" {
   secret_id     = aws_secretsmanager_secret.secret[each.value].id
   secret_string = data.sops_file.secretsmanager_secrets.data["${each.value}.value"]
 }
+{{ range .ImportSecrets }}
+import {
+  from = "{{ .From }}"
+  to   = {{ .To }}
+}
+{{ end }}
+{{ range .ImportSecretVersions }}
+import {
+  from = "{{ .From }}"
+  to   = {{ .To }}
+}
+{{ end }}
 `)
 	if err != nil {
 		return fmt.Errorf(`failed to parse template: %s`, err)
 	}
 
-	params := map[string]string{
+	params := map[string]interface{}{
 		"EncryptedSecretFileName": "secrets.encrypted.yml",
 		"Prefix":                  filter.Prefix,
+
+		"ImportSecrets": lo.Map(secrets, func(s Secret, _ int) Import {
+			return Import{
+				From: s.ARN,
+				To:   fmt.Sprintf(`aws_secretsmanager_secret.secret["%s"]`, strings.TrimPrefix(s.Key, filter.Prefix)),
+			}
+		}),
+
+		"ImportSecretVersions": lo.Map(secrets, func(s Secret, _ int) Import {
+			return Import{
+				From: fmt.Sprintf("%s|%s", s.ARN, s.Version),
+				To:   fmt.Sprintf(`aws_secretsmanager_secret_version.secret["%s"]`, strings.TrimPrefix(s.Key, filter.Prefix)),
+			}
+		}),
 	}
 
 	if err := tmpl.Execute(out, params); err != nil {

--- a/secretsmanager.go
+++ b/secretsmanager.go
@@ -136,13 +136,13 @@ resource "aws_secretsmanager_secret_version" "secret" {
 {{ range .ImportSecrets }}
 import {
   id = "{{ .id }}"
-  to   = {{ .To }}
+  to = {{ .To }}
 }
 {{ end }}
 {{ range .ImportSecretVersions }}
 import {
   id = "{{ .id }}"
-  to   = {{ .To }}
+  to = {{ .To }}
 }
 {{ end }}
 `)

--- a/secretsmanager.go
+++ b/secretsmanager.go
@@ -135,13 +135,13 @@ resource "aws_secretsmanager_secret_version" "secret" {
 }
 {{ range .ImportSecrets }}
 import {
-  from = "{{ .From }}"
+  id = "{{ .id }}"
   to   = {{ .To }}
 }
 {{ end }}
 {{ range .ImportSecretVersions }}
 import {
-  from = "{{ .From }}"
+  id = "{{ .id }}"
   to   = {{ .To }}
 }
 {{ end }}
@@ -156,15 +156,15 @@ import {
 
 		"ImportSecrets": lo.Map(secrets, func(s Secret, _ int) Import {
 			return Import{
-				From: s.ARN,
-				To:   fmt.Sprintf(`aws_secretsmanager_secret.secret["%s"]`, strings.TrimPrefix(s.Key, filter.Prefix)),
+				Id: s.ARN,
+				To: fmt.Sprintf(`aws_secretsmanager_secret.secret["%s"]`, strings.TrimPrefix(s.Key, filter.Prefix)),
 			}
 		}),
 
 		"ImportSecretVersions": lo.Map(secrets, func(s Secret, _ int) Import {
 			return Import{
-				From: fmt.Sprintf("%s|%s", s.ARN, s.Version),
-				To:   fmt.Sprintf(`aws_secretsmanager_secret_version.secret["%s"]`, strings.TrimPrefix(s.Key, filter.Prefix)),
+				Id: fmt.Sprintf("%s|%s", s.ARN, s.Version),
+				To: fmt.Sprintf(`aws_secretsmanager_secret_version.secret["%s"]`, strings.TrimPrefix(s.Key, filter.Prefix)),
 			}
 		}),
 	}

--- a/secretsmanager.go
+++ b/secretsmanager.go
@@ -175,26 +175,3 @@ import {
 
 	return nil
 }
-
-func (s SecretsManagerService) GenerateImports(ctx context.Context, filter Filter, out io.Writer) error {
-	secrets, err := s.RetrieveSecrets(ctx, filter)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve secrets: %s", err)
-	}
-
-	for _, secret := range secrets {
-		fmt.Fprintf(
-			out, "terraform import 'aws_secretsmanager_secret.secret[\"%s\"]' %s\n",
-			strings.TrimPrefix(secret.Key, filter.Prefix),
-			secret.ARN,
-		)
-		fmt.Fprintf(
-			out, "terraform import 'aws_secretsmanager_secret_version.secret[\"%s\"]' '%s|%s'\n",
-			strings.TrimPrefix(secret.Key, filter.Prefix),
-			secret.ARN,
-			secret.Version,
-		)
-	}
-
-	return nil
-}

--- a/ssm.go
+++ b/ssm.go
@@ -153,21 +153,3 @@ import {
 
 	return nil
 }
-
-func (s SSMService) GenerateImports(ctx context.Context, filter Filter, out io.Writer) error {
-	secrets, err := s.RetrieveSecrets(ctx, filter)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve secrets: %s", err)
-	}
-
-	for _, secret := range secrets {
-		fmt.Fprintf(
-			out, "terraform import 'aws_ssm_parameter.parameter[\"%s\"]' %s%s\n",
-			strings.TrimPrefix(secret.Key, filter.Prefix),
-			filter.Prefix,
-			secret.Key,
-		)
-	}
-
-	return nil
-}

--- a/types.go
+++ b/types.go
@@ -35,6 +35,6 @@ type OutSecret struct {
 }
 
 type Import struct {
-	From string
-	To   string
+	Id string
+	To string
 }

--- a/types.go
+++ b/types.go
@@ -10,7 +10,6 @@ type SecretService interface {
 	Target() string
 	RetrieveSecrets(ctx context.Context, filter Filter) ([]Secret, error)
 	GenerateTF(ctx context.Context, filter Filter, out io.Writer) error
-	GenerateImports(ctx context.Context, filter Filter, out io.Writer) error
 }
 
 type Secret struct {

--- a/types.go
+++ b/types.go
@@ -34,3 +34,8 @@ type OutSecret struct {
 	Value       string `yaml:"value"`
 	Description string `yaml:"description"`
 }
+
+type Import struct {
+	From string
+	To   string
+}


### PR DESCRIPTION
Now aws-secrets-dumper generates .tf file including [import blocks](https://developer.hashicorp.com/terraform/language/import) for target secrets.

The subcommands have changed accordingly.

- Deprecation of `generate` command
     - Due to deprecation of `generate imports`
- Added `tf` command
     - Equivalent to `generate tf`